### PR TITLE
Set BackingFile on objects that deserialize to a Backed class

### DIFF
--- a/NebulousConquestHelper/src/BackingXmlFile.cs
+++ b/NebulousConquestHelper/src/BackingXmlFile.cs
@@ -41,6 +41,10 @@ namespace NebulousConquestHelper
 					XmlSerializer serializer = new XmlSerializer(typeof(T));
 					T loaded = (T)serializer.Deserialize(stream);
 					stream.Close();
+					if (loaded is Backed<T> backed)
+					{
+						backed.BackingFile = this;
+					}
 					return loaded;
 				}
 			}


### PR DESCRIPTION
This works for things of the form `class Foo : Backed<Foo>`. If the class does not "extend itself" like that then it will not have a BackingFile.